### PR TITLE
docs: add quick start and reproducibility guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,169 +1,141 @@
 # AgentSpec
- 
-AgentSpec is a framework for enforcing safety in Large Language Model (LLM) agents via user-defined rules. It provides a programmable enforcement interface that integrates with LangChain and supports safety enforcement across embodied environments, code execution, and tool-using agents.
 
----
+AgentSpec is a framework for enforcing safety in Large Language Model (LLM) agents via user-defined rules. It integrates with LangChain and supports safety enforcement across embodied environments, code execution, and tool-using agents.
 
-## 🚀 Getting Started
+## Quick Start
 
-### 1. Installation
+This section is intended for new contributors and artifact evaluators.
+
+### 1. Prerequisites
+
+- Python 3.12+
+- Java 17+ (needed for parser regeneration)
+- Git
+
+### 2. Create and activate a virtual environment
+
+Windows PowerShell:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+macOS/Linux:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+### 3. Install dependencies
 
 ```bash
 pip install -r requirement.txt
 ```
 
-A working version:
-langchain                                0.3.25
-langchain-anthropic                      1.3.0
-langchain-classic                        1.0.1
-langchain-cli                            0.0.35
-langchain-community                      0.4.1
-langchain-core                           0.3.81
-langchain-experimental                   0.4.1
-langchain-openai                         0.3.35
-langchain-text-splitters                 0.3.11
+### 4. Verify installation with smoke tests
 
-### 2. Generate the Parser (Only required if modifying the grammar)
+These commands are deterministic and were validated locally on a fresh virtual environment.
 
 ```bash
-java -jar ./spec_lang/antlr-4.13.2-complete.jar -Dlanguage=Python3 ./spec_lang/AgentSpec.g4
+python -m unittest src.spec_lang.test_parse
+python -c "from src.spec_lang.controlled_agent_excector import initialize_controlled_agent; print('Import OK:', initialize_controlled_agent.__name__)"
+python -m py_compile src/spec_lang/demo_langchain_working.py src/spec_lang/controlled_agent_excector.py src/spec_lang/rule.py src/rules/manual/pythonrepl.py src/rules/manual/table.py
 ```
 
----
+### 5. Optional: regenerate parser from grammar
 
-## 🔧 Usage with LangChain
+Only needed if you edit `src/spec_lang/AgentSpec.g4`.
+
+```bash
+java -jar ./src/spec_lang/antlr-4.13.2-complete.jar -Dlanguage=Python3 ./src/spec_lang/AgentSpec.g4
+```
+
+### 6. Optional: use the menu runner
+
+The repository includes `run.sh` with menu options for smoke tests. If Bash reports `invalid option name: pipefail`, convert line endings to LF first.
+
+```bash
+dos2unix run.sh
+bash ./run.sh
+```
+
+## Reproducing Results
+
+For step-by-step artifact reproduction, see [REPRODUCIBILITY.md](REPRODUCIBILITY.md).
+
+That document includes:
+
+- complete setup flow,
+- exact commands for provided result artifacts,
+- known assumptions and credential requirements,
+- limitations for full end-to-end reruns.
+
+## Usage with LangChain
 
 ```python
-from controlled_agent_excector import initialize_controlled_agent 
-from langchain.tools import Tool
+from src.spec_lang.controlled_agent_excector import initialize_controlled_agent
+from src.spec_lang.rule import Rule
 from langchain_experimental.utilities import PythonREPL
 from langchain_openai import ChatOpenAI
-from langchain_community.tools import ShellTool
 
-from rule import Rule 
-import os
-import json
+llm = ChatOpenAI(model="gpt-4o", temperature=0)
 
-# Initialize the LLM
-llm = ChatOpenAI(model = "gpt-4o", temperature=0)
- 
-def demo_langchain(): 
-    
-    example_rule = """rule @check_shell_exec
-trigger 
-    PythonREPL
-check 
-    is_destructive
+example_rule = """rule @check_shell_exec
+trigger
+  PythonREPL
+check
+  is_destructive
 enforce
-    user_inspection
+  user_inspection
 end
-"""  
- 
-    rule = Rule.from_text(example_rule) 
+"""
 
-    tool = PythonREPL()  
-    # Initialize the Agent
-    tools = [tool]
-    # instead of use initialize agent from langchain, 
-    # add rule for initialize controlled agent, where rules are list of rule strings. 
-    agent = initialize_controlled_agent(tools, llm, agent="zero-shot-react-description", rules = [rule])
+rule = Rule.from_text(example_rule)
 
-    # Interact with the Agent
-    response = agent.invoke("Can you help delete the unimportant txt file in current directory")
-    print(response)
- 
+tool = PythonREPL()
+agent = initialize_controlled_agent(
+  tools=[tool],
+  llm=llm,
+  rules=[rule],
+)
+
+response = agent.invoke("Can you help delete the unimportant txt file in current directory")
+print(response)
 ```
 
-## 🔧 Customizing AgentSpec Rule
+Notes:
 
-This guide walks you through defining a safety rule in AgentSpec to prevent destructive behavior—such as unintended file deletions—by a code-generation agent.
+- `OPENAI_API_KEY` is required for OpenAI-backed examples.
+- `user_inspection` prompts on stdin by default. Pass `approval_callback=...` to integrate approval into a custom UI.
 
----
+## Customizing AgentSpec Rules
 
-### 1. **Event Name**
+1. Match the rule event name to the actual tool name.
+2. Implement a predicate function with `(user_input, tool_input, intermediate_steps)`.
+3. Register the predicate in `src/rules/manual/table.py`.
+4. Use one enforcement strategy: `stop`, `user_inspection`, `invoke_action(...)`, or `llm_self_examine`.
 
-Ensure the **event name matches the tool name** exactly. You can obtain the tool name dynamically via `tool.name` in the agent runtime environment.
+## Known Limitations
 
----
+- Some benchmark-generation/evaluation scripts require external datasets or simulators not bundled in this repository.
+- LLM-backed evaluations require API credentials and may incur usage cost.
+- If `run.sh` is checked out with CRLF line endings, Bash execution will fail until converted to LF.
 
-### 2. **Predicate Definition**
+## Citation
 
-The predicate is a Python function that determines whether a planned agent action is potentially destructive. It receives:
+If you found AgentSpec useful, please cite:
 
-- `user_input`: The original user request  
-- `tool_input`: The code string the agent is about to execute  
-- `intermediate_steps`: The agent's prior actions and decisions  
-
-#### Example: `is_destructive` Predicate
-
-```python
-import re
-
-def is_destructive(user_input, tool_input, intermediate_steps):
-    patterns = [
-        r"os\.remove",
-        r"os\.unlink",
-    ]
-    return any(re.search(pattern, tool_input) for pattern in patterns)
 ```
-
-#### Registering the Predicate
-
-1. **Extend the grammar** (`spec_lang/AgentSpec.g4`):
-
-```antlr
-PREDICATE : ... | 'is_destructive';
-```
-
-2. **Register the function** in the rule interpreter:
-
-```python
-from rules.manual.table import predicate_table
-from rule import is_destructive
-
-predicate_table['is_destructive'] = is_destructive
-``` 
----
-
-### 3. **Enforcement Strategy**
-
-Specify one of the following enforcement modes in the rule body:
-
-- **`stop`**  
-  Halts execution immediately before executing a potentially unsafe action.
-
-- **`user_inspection`**  
-  Pauses execution and prompts the user for manual approval. If the user approves, the agent continues; otherwise, it halts.
-
-- **`invoke_action(tool_name, tool_input)`**  
-  Replaces the unsafe action with a known safe alternative and executes that instead.
-
-- **`llm_self_examine`**  
-  Informs the LLM of the rule violation and prompts it to revise its plan while still trying to fulfill the original request in a safer manner.
-
---- 
-
-## Agent Implementation & Evaluation Replication
-#### For LangChain-based agent:
- - `src/code_agent`: Agent with PythonREPL as tool.
- - `src/embodied_agent`: Agent with access to robotic simulator as tool.
- - use rules in src/rules/manual/
-#### Autonomous veichles 
- - The environment is built on top of Apollo https://github.com/ApolloAuto/apollo. See [uDrive](https://arxiv.org/pdf/2407.13201) for the instrumentational version of Apollo and law-violation scenarios.
- - The AgentSpec rules for AV are in src/rules/apollo, use `src/spec_lang/translator` to translate AgentSpec rules to uDrive scripts to adjust runtime plan of AVs.
-
- ---
-
- If you found AgentSpec useful, please cite:
- ```
 @misc{wang2025agentspeccustomizableruntimeenforcement,
-      title={AgentSpec: Customizable Runtime Enforcement for Safe and Reliable LLM Agents}, 
-      author={Haoyu Wang and Christopher M. Poskitt and Jun Sun},
-      year={2025},
-      eprint={2503.18666},
-      archivePrefix={arXiv},
-      primaryClass={cs.AI},
-      url={https://arxiv.org/abs/2503.18666}, 
+    title={AgentSpec: Customizable Runtime Enforcement for Safe and Reliable LLM Agents},
+    author={Haoyu Wang and Christopher M. Poskitt and Jun Sun},
+    year={2025},
+    eprint={2503.18666},
+    archivePrefix={arXiv},
+    primaryClass={cs.AI},
+    url={https://arxiv.org/abs/2503.18666},
 }
- ```
+```
 

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -1,0 +1,138 @@
+# Reproducibility Guide
+
+This document provides concrete steps to reproduce key artifact checks and result summaries from this repository without requiring insider knowledge.
+
+## Scope
+
+This guide covers:
+
+- environment setup and dependency installation,
+- executable smoke checks for the AgentSpec runtime,
+- reproduction of packaged result summaries under `expres/`.
+
+This guide does not claim full from-scratch regeneration of every paper result because some pipelines require external datasets, simulator assets, and API credentials not fully bundled in this repository.
+
+## Prerequisites
+
+- Python 3.12+
+- Java 17+
+- Git
+- (Optional) Bash + `dos2unix` for `run.sh`
+
+## Step 1: Clone and enter the repository
+
+```bash
+git clone <repo-url>
+cd AgentSpec-CEN5016
+```
+
+## Step 2: Create a clean virtual environment
+
+Windows PowerShell:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+macOS/Linux:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+## Step 3: Install dependencies
+
+```bash
+pip install -U pip
+pip install -r requirement.txt
+```
+
+## Step 4: Reproduce core artifact checks
+
+Run these commands from repository root.
+
+### 4.1 Parser unit tests
+
+```bash
+python -m unittest src.spec_lang.test_parse
+```
+
+Expected outcome: test suite passes (`OK`).
+
+### 4.2 Controlled-agent import smoke check
+
+```bash
+python -c "from src.spec_lang.controlled_agent_excector import initialize_controlled_agent; print('Import OK:', initialize_controlled_agent.__name__)"
+```
+
+Expected outcome: prints `Import OK: initialize_controlled_agent`.
+
+### 4.3 Bytecode compilation smoke check
+
+```bash
+python -m py_compile src/spec_lang/demo_langchain_working.py src/spec_lang/controlled_agent_excector.py src/spec_lang/rule.py src/rules/manual/pythonrepl.py src/rules/manual/table.py
+```
+
+Expected outcome: no errors (warnings may appear from regex escape sequences).
+
+### 4.4 Parser regeneration check
+
+```bash
+java -jar ./src/spec_lang/antlr-4.13.2-complete.jar -Dlanguage=Python3 ./src/spec_lang/AgentSpec.g4
+```
+
+Expected outcome: command exits successfully and generated parser files are updated.
+
+## Step 5: Reproduce packaged experiment summaries
+
+The repository includes pre-generated result files in `expres/` that can be re-analyzed deterministically.
+
+### 5.1 Embodied summary
+
+```bash
+cd expres/embodied
+python analyze.py
+cd ../..
+```
+
+Expected outcome: prints aggregated rates. Example output pattern:
+
+- category lines ending with `: <rate>, <count>`
+- final overall value line
+
+### 5.2 ToolEmu file-level summary
+
+```bash
+python -c "from pathlib import Path; p=Path('expres/toolemu/gpt4o-no_controll_eval_agent_safe.jsonl'); print('toolemu safe lines:', sum(1 for _ in p.open('r', encoding='utf-8')))"
+```
+
+Expected outcome: prints a positive record count (for the current artifact, `134`).
+
+## Optional: Use the interactive runner
+
+The repository ships `run.sh` for interactive test execution.
+
+```bash
+dos2unix run.sh
+bash ./run.sh
+```
+
+Known caveat: if `run.sh` has CRLF line endings, Bash fails with `invalid option name: pipefail` until line endings are converted to LF.
+
+## Credentials and External Requirements
+
+- `OPENAI_API_KEY` is required for OpenAI-backed demo/evaluation paths.
+- `expres/embodied/detail_evaluate.py` uses OpenAI calls and AI2-THOR simulator runtime.
+- Some generation/evaluation scripts in `src/rules/llm/` reference benchmark datasets outside this repository (for example under `benchmarks/.../dataset/...`).
+
+## Known Limitations and Assumptions
+
+- Full regeneration of all paper-level metrics may require external benchmark assets not distributed here.
+- LLM-backed outcomes are partially non-deterministic and sensitive to model version, API behavior, and rate limits.
+- If your shell is PowerShell, prefer direct `python ...` commands over Bash heredoc syntax (`<<'PY'`).
+
+## Verification Status for This Guide
+
+Commands in this file were verified to execute on a fresh local virtual environment on Windows (PowerShell) on 2026-04-14, except steps explicitly marked as requiring external credentials/assets.


### PR DESCRIPTION
## Summary

This PR improves the artifact documentation for new contributors and evaluators by adding a clearer onboarding path and a dedicated reproducibility guide.

## What Changed

- updated `README.md` with a Quick Start section
- documented environment setup for Windows PowerShell and macOS/Linux
- added dependency installation and smoke-test commands
- documented optional parser regeneration and `run.sh` usage
- added `REPRODUCIBILITY.md` with step-by-step reproduction instructions
- documented required credentials, assumptions, and known limitations

## Why

The previous README assumed too much prior knowledge and did not provide a complete path for independently setting up and validating the artifact. This PR makes the repository easier to install, run, and evaluate without insider context.

## Verification

The documented commands were validated locally, including:

- creating a fresh virtual environment
- installing dependencies from `requirement.txt`
- running parser unit tests
- running the controlled-agent import smoke check
- running bytecode compilation checks
- regenerating the parser with ANTLR
- re-running packaged result summaries from `expres/`

## Notes

- OpenAI-backed flows still require `OPENAI_API_KEY`
- some full paper pipelines depend on external datasets/assets not bundled in the repo
- `run.sh` may require LF line endings when run under Bash